### PR TITLE
feat: filter pools to only track AAVE Arbitrum tokens

### DIFF
--- a/config/arbitrum-one/chain.ts
+++ b/config/arbitrum-one/chain.ts
@@ -15,13 +15,35 @@ export const ROLL_DELETE_MINUTE = 1680
 export const ROLL_DELETE_HOUR_LIMITER = BigInt.fromI32(500)
 export const ROLL_DELETE_MINUTE_LIMITER = BigInt.fromI32(1000)
 
+// AAVE Arbitrum tokens - only pools with BOTH tokens in this list will be tracked
+export const AAVE_ARBITRUM_TOKENS: string[] = [
+  '0x82af49447d8a07e3bd95bd0d56f35241523fbab1', // ETH (WETH)
+  '0xaf88d065e77c8cc2239327c5edb3a432268e5831', // USDC
+  '0x35751007a407ca6feffe80b3cb397736d2cf4dbe', // weETH
+  '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f', // WBTC
+  '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9', // USDT
+  '0xf97f4df75117a78c1a5a0dbb814af92458539fb4', // LINK
+  '0x912ce59144191c1204e64559fe8253a0e49e6548', // ARB
+  '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1', // DAI
+  '0xba5ddd1f9d7f570dc94a51479a000e3bce967196', // AAVE
+  '0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0', // UNI
+  '0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34', // USDe
+]
+
 // token where amounts should contribute to tracked volume and liquidity
-// usually tokens that many tokens are paired with s
+// updated to include all AAVE tokens for accurate price derivation
 export const WHITELIST_TOKENS: string[] = [
   '0x82af49447d8a07e3bd95bd0d56f35241523fbab1', // WETH
-  '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8', // USDC
-  '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1', // DAI
+  '0xaf88d065e77c8cc2239327c5edb3a432268e5831', // USDC
+  '0x35751007a407ca6feffe80b3cb397736d2cf4dbe', // weETH
+  '0x2f2a2543b76a4166549f7aab2e75bef0aefc5b0f', // WBTC
   '0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9', // USDT
+  '0xf97f4df75117a78c1a5a0dbb814af92458539fb4', // LINK
+  '0x912ce59144191c1204e64559fe8253a0e49e6548', // ARB
+  '0xda10009cbd5d07dd0cecc66161fc93d7c9000da1', // DAI
+  '0xba5ddd1f9d7f570dc94a51479a000e3bce967196', // AAVE
+  '0xfa7f8980b0f1e64a2062791cc3b0871572f1f7f0', // UNI
+  '0x5d3a1ff2b6bab83b63cd9ad0787074081a52ef34', // USDe
 ]
 
 export const STABLE_COINS: string[] = [

--- a/networks.json
+++ b/networks.json
@@ -1,0 +1,12 @@
+{
+  "arbitrum-one": {
+    "Factory": {
+      "address": "0x1F98431c8aD98523631AE4a59f267346ea31F984",
+      "startBlock": 175
+    },
+    "NonfungiblePositionManager": {
+      "address": "0xC36442b4a4522E871399CD717aBDD847Ab11FE88",
+      "startBlock": 175
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "license": "GPL-3.0-or-later",
   "scripts": {
     "build": "cross-env ts-node ./script/build",
-    "lint": "eslint . --ext .ts --fix"
+    "lint": "eslint . --ext .ts --fix",
+    "deploy:arbitrum-one": "source .env && graph deploy --node https://subgraph.0xnode.cloud/deploy/ --ipfs https://ipfs.0xnode.cloud -l 0.0.1 --network arbitrum-one kittycorn-arbitrum-one/v3-subgraph-filtered v3-subgraph.yaml --access-token $DEPLOY_KEY",
+    "create:arbitrum-one": "source .env && graph create --node https://subgraph.0xnode.cloud/deploy/ kittycorn-arbitrum-one/v3-subgraph-filtered --access-token $DEPLOY_KEY",
+    "remove:arbitrum-one": "source .env && graph remove --node https://subgraph.0xnode.cloud/deploy/ kittycorn-arbitrum-one/v3-subgraph-filtered --access-token $DEPLOY_KEY"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "^0.64.1",

--- a/src/v3/mappings/burn.ts
+++ b/src/v3/mappings/burn.ts
@@ -17,8 +17,13 @@ import { loadTransaction } from './utils'
 export function handleBurn(event: BurnEvent): void {
   const factoryAddress = Address.fromString(FACTORY_ADDRESS)
 
+  // Check if pool exists (may be filtered out by whitelist)
+  const pool = Pool.load(event.address)
+  if (pool === null) {
+    return
+  }
+
   const bundle = Bundle.load('1')!
-  const pool = Pool.load(event.address)!
   const factory = Factory.load(factoryAddress.toHexString())!
 
   const token0 = Token.load(pool.token0)

--- a/src/v3/mappings/collect.ts
+++ b/src/v3/mappings/collect.ts
@@ -18,11 +18,13 @@ import { loadTransaction } from './utils'
 export function handleCollect(event: CollectEvent): void {
   const factoryAddress = Address.fromString(FACTORY_ADDRESS)
 
-  const bundle = Bundle.load('1')!
-  const pool = Pool.load(event.address)!
-  if (pool == null) {
+  // Check if pool exists (may be filtered out by whitelist)
+  const pool = Pool.load(event.address)
+  if (pool === null) {
     return
   }
+
+  const bundle = Bundle.load('1')!
   const transaction = loadTransaction(event)
   const factory = Factory.load(factoryAddress.toHexString())!
 

--- a/src/v3/mappings/factory.ts
+++ b/src/v3/mappings/factory.ts
@@ -4,7 +4,7 @@ import { PoolCreated } from '../../../generated/Factory/Factory'
 import { Bundle, Factory, Pool, Token } from '../../../generated/schema'
 import { Pool as PoolTemplate } from '../../../generated/templates'
 import { populateEmptyPools } from '../../common/backfill'
-import { FACTORY_ADDRESS, POOL_MAPINGS, SKIP_POOLS, WHITELIST_TOKENS } from '../../common/chain'
+import { AAVE_ARBITRUM_TOKENS, FACTORY_ADDRESS, POOL_MAPINGS, SKIP_POOLS, WHITELIST_TOKENS } from '../../common/chain'
 import { fetchTokenDecimals, fetchTokenName, fetchTokenSymbol, fetchTokenTotalSupply } from '../../common/token'
 import { ADDRESS_ZERO, ONE_BI, ZERO_BD, ZERO_BI } from './../../common/constants'
 
@@ -101,6 +101,13 @@ export function handlePoolCreated(event: PoolCreated): void {
     token1.txCount = ZERO_BI
     token1.poolCount = ZERO_BI
     token1.whitelistPools = []
+  }
+
+  // Filter: Only track pools where BOTH tokens are in AAVE whitelist
+  const token0Addr = token0.id.toHexString().toLowerCase()
+  const token1Addr = token1.id.toHexString().toLowerCase()
+  if (!AAVE_ARBITRUM_TOKENS.includes(token0Addr) || !AAVE_ARBITRUM_TOKENS.includes(token1Addr)) {
+    return
   }
 
   // update white listed pools

--- a/src/v3/mappings/initialize.ts
+++ b/src/v3/mappings/initialize.ts
@@ -6,8 +6,13 @@ import { findEthPerToken, getEthPriceInUSD } from '../../common/pricing'
 import { updatePoolDayData, updatePoolHourData } from './intervalUpdates'
 
 export function handleInitialize(event: Initialize): void {
+  // Check if pool exists (may be filtered out by whitelist)
+  const pool = Pool.load(event.address)
+  if (pool === null) {
+    return
+  }
+
   // update pool sqrt price and tick
-  const pool = Pool.load(event.address)!
   pool.sqrtPrice = event.params.sqrtPriceX96
   pool.tick = BigInt.fromI32(event.params.tick)
   pool.save()

--- a/src/v3/mappings/mint.ts
+++ b/src/v3/mappings/mint.ts
@@ -18,8 +18,13 @@ import { loadTransaction } from './utils'
 export function handleMint(event: MintEvent): void {
   const factoryAddress = Address.fromString(FACTORY_ADDRESS)
 
+  // Check if pool exists (may be filtered out by whitelist)
+  const pool = Pool.load(event.address)
+  if (pool === null) {
+    return
+  }
+
   const bundle = Bundle.load('1')!
-  const pool = Pool.load(event.address)!
   const factory = Factory.load(factoryAddress.toHexString())!
 
   const token0 = Token.load(pool.token0)

--- a/src/v3/mappings/position-manager.ts
+++ b/src/v3/mappings/position-manager.ts
@@ -1,0 +1,219 @@
+import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts'
+
+import {
+  Collect,
+  DecreaseLiquidity,
+  IncreaseLiquidity,
+  NonfungiblePositionManager,
+  Transfer,
+} from '../../../generated/NonfungiblePositionManager/NonfungiblePositionManager'
+import { Pool, Position, PositionSnapshot, Token, Tick } from '../../../generated/schema'
+import { ADDRESS_ZERO, factoryContract, ZERO_BD, ZERO_BI } from '../../common/constants'
+import { convertTokenToDecimal } from '../../common/utils'
+import { loadTransaction } from './utils'
+
+function getPosition(event: ethereum.Event, tokenId: BigInt): Position | null {
+  let position = Position.load(tokenId.toString())
+  if (position === null) {
+    const contract = NonfungiblePositionManager.bind(event.address)
+    const positionCall = contract.try_positions(tokenId)
+
+    if (!positionCall.reverted) {
+      const positionResult = positionCall.value
+      const poolAddress = factoryContract.getPool(positionResult.value2, positionResult.value3, positionResult.value4)
+
+      // Check if pool exists (may be filtered out by whitelist)
+      const pool = Pool.load(poolAddress)
+      if (pool === null) {
+        return null
+      }
+
+      position = new Position(tokenId.toString())
+      position.owner = Address.fromString(ADDRESS_ZERO)
+      position.pool = poolAddress
+      position.token0 = positionResult.value2
+      position.token1 = positionResult.value3
+      const tickLowerIdx = positionResult.value5
+      const tickUpperIdx = positionResult.value6
+      const tickLowerId = poolAddress.toHexString().concat('#').concat(tickLowerIdx.toString())
+      const tickUpperId = poolAddress.toHexString().concat('#').concat(tickUpperIdx.toString())
+
+      // Load or create tick entities
+      let tickLower = Tick.load(tickLowerId)
+      let tickUpper = Tick.load(tickUpperId)
+
+      if (!tickLower) {
+        tickLower = new Tick(tickLowerId)
+        tickLower.tickIdx = BigInt.fromI32(tickLowerIdx)
+        tickLower.pool = poolAddress
+        tickLower.poolAddress = poolAddress
+        tickLower.liquidityGross = ZERO_BI
+        tickLower.liquidityNet = ZERO_BI
+        tickLower.price0 = ZERO_BD
+        tickLower.price1 = ZERO_BD
+        tickLower.createdAtTimestamp = event.block.timestamp
+        tickLower.createdAtBlockNumber = event.block.number
+        tickLower.save()
+      }
+
+      if (!tickUpper) {
+        tickUpper = new Tick(tickUpperId)
+        tickUpper.tickIdx = BigInt.fromI32(tickUpperIdx)
+        tickUpper.pool = poolAddress
+        tickUpper.poolAddress = poolAddress
+        tickUpper.liquidityGross = ZERO_BI
+        tickUpper.liquidityNet = ZERO_BI
+        tickUpper.price0 = ZERO_BD
+        tickUpper.price1 = ZERO_BD
+        tickUpper.createdAtTimestamp = event.block.timestamp
+        tickUpper.createdAtBlockNumber = event.block.number
+        tickUpper.save()
+      }
+
+      position.tickLower = tickLowerId
+      position.tickUpper = tickUpperId
+      position.liquidity = ZERO_BI
+      position.depositedToken0 = ZERO_BD
+      position.depositedToken1 = ZERO_BD
+      position.withdrawnToken0 = ZERO_BD
+      position.withdrawnToken1 = ZERO_BD
+      position.collectedToken0 = ZERO_BD
+      position.collectedToken1 = ZERO_BD
+      position.collectedFeesToken0 = ZERO_BD
+      position.collectedFeesToken1 = ZERO_BD
+      position.transaction = loadTransaction(event).id
+      position.feeGrowthInside0LastX128 = positionResult.value8
+      position.feeGrowthInside1LastX128 = positionResult.value9
+    }
+  }
+
+  return position
+}
+
+function updateFeeVars(position: Position, event: ethereum.Event, tokenId: BigInt): Position {
+  const positionManagerContract = NonfungiblePositionManager.bind(event.address)
+  const positionResult = positionManagerContract.try_positions(tokenId)
+  if (!positionResult.reverted) {
+    position.feeGrowthInside0LastX128 = positionResult.value.value8
+    position.feeGrowthInside1LastX128 = positionResult.value.value9
+  }
+  return position
+}
+
+function savePositionSnapshot(position: Position, event: ethereum.Event): void {
+  const positionSnapshot = new PositionSnapshot(position.id.concat('#').concat(event.block.number.toString()))
+  positionSnapshot.owner = position.owner
+  positionSnapshot.pool = position.pool
+  positionSnapshot.position = position.id
+  positionSnapshot.blockNumber = event.block.number
+  positionSnapshot.timestamp = event.block.timestamp
+  positionSnapshot.liquidity = position.liquidity
+  positionSnapshot.depositedToken0 = position.depositedToken0
+  positionSnapshot.depositedToken1 = position.depositedToken1
+  positionSnapshot.withdrawnToken0 = position.withdrawnToken0
+  positionSnapshot.withdrawnToken1 = position.withdrawnToken1
+  positionSnapshot.collectedFeesToken0 = position.collectedFeesToken0
+  positionSnapshot.collectedFeesToken1 = position.collectedFeesToken1
+  positionSnapshot.transaction = loadTransaction(event).id
+  positionSnapshot.feeGrowthInside0LastX128 = position.feeGrowthInside0LastX128
+  positionSnapshot.feeGrowthInside1LastX128 = position.feeGrowthInside1LastX128
+  positionSnapshot.save()
+}
+
+export function handleIncreaseLiquidity(event: IncreaseLiquidity): void {
+  const position = getPosition(event, event.params.tokenId)
+
+  if (position == null) {
+    return
+  }
+
+  const token0 = Token.load(position.token0)
+  const token1 = Token.load(position.token1)
+
+  if (!token0 || !token1) {
+    return
+  }
+
+  const amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
+  const amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
+
+  position.liquidity = position.liquidity.plus(event.params.liquidity)
+  position.depositedToken0 = position.depositedToken0.plus(amount0)
+  position.depositedToken1 = position.depositedToken1.plus(amount1)
+
+  updateFeeVars(position, event, event.params.tokenId)
+
+  position.save()
+
+  savePositionSnapshot(position, event)
+}
+
+export function handleDecreaseLiquidity(event: DecreaseLiquidity): void {
+  let position = getPosition(event, event.params.tokenId)
+
+  if (position == null) {
+    return
+  }
+
+  const token0 = Token.load(position.token0)
+  const token1 = Token.load(position.token1)
+
+  if (!token0 || !token1) {
+    return
+  }
+
+  const amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
+  const amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
+
+  position.liquidity = position.liquidity.minus(event.params.liquidity)
+  position.withdrawnToken0 = position.withdrawnToken0.plus(amount0)
+  position.withdrawnToken1 = position.withdrawnToken1.plus(amount1)
+
+  position = updateFeeVars(position, event, event.params.tokenId)
+
+  position.save()
+
+  savePositionSnapshot(position, event)
+}
+
+export function handleCollect(event: Collect): void {
+  let position = getPosition(event, event.params.tokenId)
+
+  if (position == null) {
+    return
+  }
+
+  const token0 = Token.load(position.token0)
+  const token1 = Token.load(position.token1)
+
+  if (!token0 || !token1) {
+    return
+  }
+
+  const amount0 = convertTokenToDecimal(event.params.amount0, token0.decimals)
+  const amount1 = convertTokenToDecimal(event.params.amount1, token1.decimals)
+  position.collectedToken0 = position.collectedToken0.plus(amount0)
+  position.collectedToken1 = position.collectedToken1.plus(amount1)
+
+  position.collectedFeesToken0 = position.collectedToken0.minus(position.withdrawnToken0)
+  position.collectedFeesToken1 = position.collectedToken1.minus(position.withdrawnToken1)
+
+  position = updateFeeVars(position, event, event.params.tokenId)
+
+  position.save()
+
+  savePositionSnapshot(position, event)
+}
+
+export function handleTransfer(event: Transfer): void {
+  const position = getPosition(event, event.params.tokenId)
+
+  if (position == null) {
+    return
+  }
+
+  position.owner = event.params.to
+  position.save()
+
+  savePositionSnapshot(position, event)
+}

--- a/src/v3/mappings/swap.ts
+++ b/src/v3/mappings/swap.ts
@@ -18,9 +18,14 @@ import { loadTransaction } from './utils'
 export function handleSwap(event: SwapEvent): void {
   const factoryAddress = Address.fromString(FACTORY_ADDRESS)
 
+  // Check if pool exists (may be filtered out by whitelist)
+  const pool = Pool.load(event.address)
+  if (pool === null) {
+    return
+  }
+
   const bundle = Bundle.load('1')!
   const factory = Factory.load(factoryAddress.toHexString())!
-  const pool = Pool.load(event.address)!
 
   // hot fix for bad pricing
   if (pool.id.toHexString().toLowerCase() == '0x9663f2ca0454accad3e094448ea6f77443880454') {


### PR DESCRIPTION
## Summary
- Filter pool creation to only track pools where **BOTH** tokens are in the AAVE Arbitrum whitelist (11 tokens: WETH, USDC, weETH, WBTC, USDT, LINK, ARB, DAI, AAVE, UNI, USDe)
- Add null guards in all event handlers to gracefully skip events for non-tracked pools
- Significantly reduces entity count by excluding pools that don't contain both AAVE tokens

## Changes
- `config/arbitrum-one/chain.ts`: Add `AAVE_ARBITRUM_TOKENS` array and update `WHITELIST_TOKENS`
- `src/v3/mappings/factory.ts`: Filter pool creation to skip non-AAVE token pools
- `src/v3/mappings/swap.ts`, `mint.ts`, `burn.ts`, `collect.ts`, `initialize.ts`: Add null guards for pool
- `src/v3/mappings/position-manager.ts`: Add pool existence check
- `networks.json`: Add network configuration file

## Test plan
- [ ] Run `yarn build` to verify compilation
- [ ] Deploy to Graph Studio and verify only AAVE token pools are indexed
- [ ] Verify entity count is significantly reduced compared to unfiltered subgraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)